### PR TITLE
Fix for Windows compatibility and rename to Shotgrid

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -81,7 +81,7 @@ class TDEqualizerEngine(Engine):
         if self.has_ui:
             from sgtk.platform.qt import QtCore, QtGui
 
-            self.logger.info("Creating Shotgun menu...")
+            self.logger.info("Creating Shotgrid menu...")
 
             self._cleanup_custom_scripts_dir_path()
 
@@ -106,7 +106,7 @@ class TDEqualizerEngine(Engine):
                     "\n".join(
                         (
                             "# 3DE4.script.name: {}".format(name),
-                            "# 3DE4.script.gui:	Main Window::Shotgun",
+                            "# 3DE4.script.gui:	Main Window::Shotgrid",
                             "if __name__ == '__main__':",
                             "   import sgtk",
                             "   sgtk.platform.current_engine().commands[{}]['callback']()".format(
@@ -119,7 +119,7 @@ class TDEqualizerEngine(Engine):
 
             QtCore.QTimer.singleShot(0, tde4.rescanPythonDirs)
 
-            self.logger.info("Shotgun menu created.")
+            self.logger.info("Shotgrid menu created.")
 
             return True
         return False
@@ -139,9 +139,9 @@ class TDEqualizerEngine(Engine):
 
     def _emit_log_message(self, handler, record):
         if record.levelno < logging.INFO:
-            formatter = logging.Formatter("Debug: Shotgun %(basename)s: %(message)s")
+            formatter = logging.Formatter("Debug: Shotgrid %(basename)s: %(message)s")
         else:
-            formatter = logging.Formatter("Shotgun %(basename)s: %(message)s")
+            formatter = logging.Formatter("Shotgrid %(basename)s: %(message)s")
         msg = formatter.format(record)
         print(msg)
 

--- a/startup.py
+++ b/startup.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import tempfile
 
 import sgtk
 from sgtk.platform import SoftwareLauncher, LaunchInformation
@@ -26,11 +27,15 @@ class TDE4Launcher(SoftwareLauncher):
         required_env = {}
 
         # Run the engine's startup/*.py files when 3DEqualizer starts up
-        startup_path = os.path.join(self.disk_location, "startup")
-        os.environ["PYTHON_CUSTOM_SCRIPTS_3DE4"] = startup_path
-        required_env["PYTHON_CUSTOM_SCRIPTS_3DE4"] = os.environ[
-            "PYTHON_CUSTOM_SCRIPTS_3DE4"
-        ]
+        startup_path = os.path.join(self.disk_location, 'startup')
+
+        # Get path to temp menu folder, and add it to the environment.
+        menufolder = tempfile.mkdtemp(prefix='tk-3dequalizer_')
+        required_env['TK_3DE4_MENU_DIR'] = menufolder
+
+        required_env['PYTHON_CUSTOM_SCRIPTS_3DE4'] = os.pathsep.join(
+            [x for x in os.getenv('PYTHON_CUSTOM_SCRIPTS_3DE4', '').split(os.pathsep) if x]
+            + [startup_path, menufolder])
 
         # Add context information info to the env.
         required_env["TANK_CONTEXT"] = sgtk.Context.serialize(self.context)


### PR DESCRIPTION
- Original commit changes, making engine compatible with Windows, introduced in https://github.com/splidje/tk-3dequalizer/pull/2 were not included into the latest master version of https://github.com/splidje/tk-3dequalizer
- Rename Shotgun to Shotgrid in the menu